### PR TITLE
BUG: Fix typo in name of check instance optional key map function

### DIFF
--- a/kim_property/__init__.py
+++ b/kim_property/__init__.py
@@ -390,7 +390,7 @@ from .instance import \
     check_optional_key_source_value_scalar, \
     get_optional_key_source_value_ndimensions, \
     check_instance_optional_key_standard_pairs_format, \
-    check_instnace_optional_key_map, \
+    check_instance_optional_key_map, \
     check_instance_optional_key_marked_required_are_present, \
     check_property_instances
 from .create import get_properties, kim_property_create, unset_property_id
@@ -419,7 +419,7 @@ __all__ = [
     "check_optional_key_source_value_scalar",
     "get_optional_key_source_value_ndimensions",
     "check_instance_optional_key_standard_pairs_format",
-    "check_instnace_optional_key_map",
+    "check_instance_optional_key_map",
     "check_instance_optional_key_marked_required_are_present",
     "check_property_instances",
     "get_properties",

--- a/kim_property/instance.py
+++ b/kim_property/instance.py
@@ -24,7 +24,7 @@ __all__ = [
     "check_optional_key_source_value_scalar",
     "get_optional_key_source_value_ndimensions",
     "check_instance_optional_key_standard_pairs_format",
-    "check_instnace_optional_key_map",
+    "check_instance_optional_key_map",
     "check_instance_optional_key_marked_required_are_present",
     "check_property_instances",
 ]
@@ -309,7 +309,7 @@ def check_instance_optional_key_standard_pairs_format(property_instance_map,
 KEY_FORMAT = re.compile(r'^[a-z0-9\-].*$', FLAGS)
 
 
-def check_instnace_optional_key_map(property_instance_key,
+def check_instance_optional_key_map(property_instance_key,
                                     property_instance_map,
                                     property_definition_map=None,
                                     _m=KEY_FORMAT.match):
@@ -416,7 +416,7 @@ def check_property_instances(fi, fp=None, fp_path=None, _m=KEY_FORMAT.match):
         msg += 'or a KIM property file should be provided (not both).'
         raise KIMPropertyError(msg)
 
-    # Property instnace
+    # Property instance
     if isinstance(fi, (list, dict)):
         pi = fi
     else:
@@ -480,9 +480,9 @@ def check_property_instances(fi, fp=None, fp_path=None, _m=KEY_FORMAT.match):
         for k in pi:
             if k not in required_keys:
                 if k in pd:
-                    check_instnace_optional_key_map(k, pi[k], pd[k], _m=_m)
+                    check_instance_optional_key_map(k, pi[k], pd[k], _m=_m)
                 else:
-                    check_instnace_optional_key_map(k, pi[k], _m=_m)
+                    check_instance_optional_key_map(k, pi[k], _m=_m)
 
     elif isinstance(pi, list):
         instance_id = []
@@ -555,10 +555,10 @@ def check_property_instances(fi, fp=None, fp_path=None, _m=KEY_FORMAT.match):
             for k in pi_:
                 if k not in required_keys:
                     if k in pd:
-                        check_instnace_optional_key_map(
+                        check_instance_optional_key_map(
                             k, pi_[k], pd[k], _m=_m)
                     else:
-                        check_instnace_optional_key_map(k, pi_[k], _m=_m)
+                        check_instance_optional_key_map(k, pi_[k], _m=_m)
     else:
         msg = 'input to the function does not have a correct KIM-EDN format.'
         raise KIMPropertyError(msg)

--- a/tests/test_kim_property/test_instance.py
+++ b/tests/test_kim_property/test_instance.py
@@ -258,11 +258,11 @@ class TestPropertyInstanceModuleComponents:
                           self.kim_property.check_instance_optional_key_standard_pairs_format,
                           {"source-value": [3.9149], "source-unit": "angstrom", "unknown": 5}, None)
 
-    def test_check_instnace_optional_key_map(self):
+    def test_check_instance_optional_key_map(self):
         """Test the inctances optional fields key-map pairs correctness."""
         # the key format is not correct
         self.assertRaises(self.KIMPropertyError,
-                          self.kim_property.check_instnace_optional_key_map,
+                          self.kim_property.check_instance_optional_key_map,
                           "A", {"source-unit": "angstrom", "digits": 5})
 
     def test_check_instance_optional_key_marked_required_are_present(self):


### PR DESCRIPTION
The word "instance" was misspelled "instnace" in the function `check_instnace_optional_key_map`.